### PR TITLE
Fix typo in completion prompt

### DIFF
--- a/gpt-ffmpeg.py
+++ b/gpt-ffmpeg.py
@@ -19,7 +19,7 @@ def generate_completion(prompt, input_file):
     """
     Use the OpenAI Completion API to generate a completion for the given prompt.
     """
-    prompt = (f"Genearate an ffmpeg prompt in response to a request below. Do not respond with anything other than the ffmpeg command itself. Name the output file 'output' with the relvant extension except in the case of a repeated output pattern.\n\nRequest:{prompt}\n\nffmpeg -i {input_file}"
+    prompt = (f"Generate an ffmpeg prompt in response to a request below. Do not respond with anything other than the ffmpeg command itself. Name the output file 'output' with the relevant extension except in the case of a repeated output pattern.\n\nRequest:{prompt}\n\nffmpeg -i {input_file}"
              )
 
     completions = openai.Completion.create(


### PR DESCRIPTION
## Summary
- correct spelling in completion prompt text

## Testing
- `python3 -m py_compile gpt-ffmpeg.py`

------
https://chatgpt.com/codex/tasks/task_e_6840e1099ff483218532ed3502c16e9b