### PR TITLE
Update openai API to latest client

### DIFF
--- a/gpt-ffmpeg.py
+++ b/gpt-ffmpeg.py
@@ -1,59 +1,64 @@
 #!/opt/homebrew/bin/python3
 import argparse
-import openai
+from openai import OpenAI
 import subprocess
 import os
 import json
 import re
 from termcolor import colored
 
+client = None
+
 def load_config():
     """
     Load the configuration from a JSON file.
     """
-    with open("/usr/local/bin/config.json") as f:
+    script_dir = os.path.dirname(os.path.abspath(__file__))
+    config_path = os.path.join(script_dir, "config.json")
+    with open(config_path) as f:
         config = json.load(f)
     return config
 
 def generate_completion(prompt, input_file):
     """
-    Use the OpenAI Completion API to generate a completion for the given prompt.
+    Use the OpenAI Chat Completion API to generate a completion for the given prompt.
     """
-    prompt = (f"Genearate an ffmpeg prompt in response to a request below. Do not respond with anything other than the ffmpeg command itself. Name the output file 'output' with the relvant extension except in the case of a repeated output pattern.\n\nRequest:{prompt}\n\nffmpeg -i {input_file}"
-             )
+    prompt = (
+        "Genearate an ffmpeg prompt in response to a request below. Do not respond "
+        "with anything other than the ffmpeg command itself. Name the output file "
+        "'output' with the relvant extension except in the case of a repeated output pattern.\n\n"
+        f"Request:{prompt}\n\nffmpeg -i {input_file}"
+    )
 
-    completions = openai.Completion.create(
-        engine="text-davinci-003",
-        prompt=prompt,
+    response = client.chat.completions.create(
+        model="gpt-3.5-turbo",
+        messages=[{"role": "user", "content": prompt}],
         max_tokens=500,
-        n=1,
-        stop=None,
         temperature=0.0,
     )
 
-    message = completions.choices[0].text
+    message = response.choices[0].message.content
     return message
 
-def fix_command(command,input_prompt):
+def fix_command(command, input_prompt):
     """
-    Use the OpenAI Completion API to fix an erroneous FFmpeg command.
+    Use the OpenAI Chat Completion API to fix an erroneous FFmpeg command.
     """
     # Set the prompt for the Completion API
-    prompt = (f"Fix the following FFmpeg command. The intended functionality is to {input_prompt}:\n\n{command}\n\nFFmpeg "
-             )
+    prompt = (
+        f"Fix the following FFmpeg command. The intended functionality is to {input_prompt}:\n\n{command}\n\nFFmpeg "
+    )
 
-    # Use the Completion API to generate a fixed version of the command
-    completions = openai.Completion.create(
-        engine="text-davinci-002",
-        prompt=prompt,
+    # Use the Chat Completion API to generate a fixed version of the command
+    response = client.chat.completions.create(
+        model="gpt-3.5-turbo",
+        messages=[{"role": "user", "content": prompt}],
         max_tokens=500,
-        n=1,
-        stop=None,
         temperature=0.0,
     )
 
     # Return the fixed command
-    return completions.choices[0].text
+    return response.choices[0].message.content
 
 
 def validate_command(command):
@@ -99,7 +104,7 @@ def main():
     command = 'ffmpeg '+input_files+' '+completion+'"'
 
     # Run command back through GPT to correct any errors
-    fixed_command = "ffmpeg" + fix_command(command,args.prompt)
+    fixed_command = fix_command(command, args.prompt).strip()
 
     if (validate_command(fixed_command)):
         # Run the FFmpeg command using subprocess
@@ -111,6 +116,5 @@ def main():
         print(colored("Failed command: "+command,"red"))
 
 if __name__ == "__main__":
-    # Replace YOUR_API_KEY with your actual API key
-    openai.api_key = load_config()["api_key"]
+    client = OpenAI(api_key=load_config()["api_key"])
     main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
-openai
-argparse
+openai>=1.0.0
 termcolor

--- a/tests/test_gpt_ffmpeg.py
+++ b/tests/test_gpt_ffmpeg.py
@@ -1,0 +1,81 @@
+import sys
+import types
+import importlib.util
+from unittest.mock import MagicMock
+import pytest
+
+# provide a dummy termcolor so the module can be imported without dependencies
+termcolor_mock = types.ModuleType("termcolor")
+termcolor_mock.colored = lambda text, *a, **k: text
+sys.modules['termcolor'] = termcolor_mock
+
+# create dummy openai module implementing the OpenAI client and
+# chat.completions.create that returns different commands depending
+# on the prompt so we can test prompt\u2192command pairs
+def chat_create_side_effect(model, messages, max_tokens, temperature):
+    content = messages[0]["content"]
+    if "resize" in content:
+        msg = "-vf scale=640:480 output.mp4"
+    elif "convert to mp3" in content:
+        msg = "-vn -ar 44100 -ac 2 -b:a 192k output.mp3"
+    elif "extract frames" in content:
+        msg = "-vf fps=5 output_%03d.png"
+    else:
+        msg = "-c:v libx264 output.mp4"
+    return types.SimpleNamespace(
+        choices=[types.SimpleNamespace(message=types.SimpleNamespace(content=msg))]
+    )
+
+completions_mock = MagicMock()
+completions_mock.create = MagicMock(side_effect=chat_create_side_effect)
+
+class DummyOpenAI:
+    def __init__(self, *a, **k):
+        self.chat = types.SimpleNamespace(completions=completions_mock)
+
+openai_mock = types.ModuleType("openai")
+openai_mock.OpenAI = DummyOpenAI
+sys.modules["openai"] = openai_mock
+
+# load the target module after injecting openai
+spec = importlib.util.spec_from_file_location("gpt_ffmpeg", "gpt-ffmpeg.py")
+gpt_ffmpeg = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(gpt_ffmpeg)
+gpt_ffmpeg.client = DummyOpenAI()
+
+
+def test_generate_completion_calls_chat_api():
+    result = gpt_ffmpeg.generate_completion("resize", "input.mp4")
+    assert "output" in result
+    completions_mock.create.assert_called_once()
+    assert completions_mock.create.call_args[1]["model"] == "gpt-3.5-turbo"
+
+
+@pytest.mark.parametrize(
+    "prompt,expected",
+    [
+        ("resize", "-vf scale=640:480 output.mp4"),
+        ("convert to mp3", "-vn -ar 44100 -ac 2 -b:a 192k output.mp3"),
+        ("extract frames", "-vf fps=5 output_%03d.png"),
+    ],
+)
+def test_generate_completion_various_prompts(prompt, expected):
+    completions_mock.create.reset_mock()
+    result = gpt_ffmpeg.generate_completion(prompt, "input.mp4")
+    assert result == expected
+    completions_mock.create.assert_called_once()
+    called_msg = completions_mock.create.call_args[1]["messages"][0]["content"]
+    assert prompt in called_msg
+
+
+def test_fix_command_calls_chat_api():
+    completions_mock.create.reset_mock()
+    result = gpt_ffmpeg.fix_command("ffmpeg -i input.mp4", "resize")
+    assert isinstance(result, str)
+    completions_mock.create.assert_called_once()
+    assert completions_mock.create.call_args[1]["model"] == "gpt-3.5-turbo"
+
+
+def test_validate_command():
+    assert not gpt_ffmpeg.validate_command("rm -rf /")
+    assert gpt_ffmpeg.validate_command("ffmpeg -i in.mp4 out.mp4")


### PR DESCRIPTION
## Summary
- incorporate changes from `main`
- switch to `OpenAI` client with `chat.completions.create`
- adjust tests for new OpenAI client mocking

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6840df1d421c8321ab320bbea00b33fb