### PR TITLE
Fix ffmpeg prefix when correcting commands

### DIFF
--- a/gpt-ffmpeg.py
+++ b/gpt-ffmpeg.py
@@ -57,8 +57,11 @@ def fix_command(command, input_prompt):
         temperature=0.0,
     )
 
-    # Return the fixed command
-    return response.choices[0].message.content
+    fixed = response.choices[0].message.content.strip()
+    if not fixed.lower().startswith("ffmpeg"):
+        fixed = "ffmpeg " + fixed
+
+    return fixed
 
 
 def validate_command(command):

--- a/tests/test_gpt_ffmpeg.py
+++ b/tests/test_gpt_ffmpeg.py
@@ -72,6 +72,7 @@ def test_fix_command_calls_chat_api():
     completions_mock.create.reset_mock()
     result = gpt_ffmpeg.fix_command("ffmpeg -i input.mp4", "resize")
     assert isinstance(result, str)
+    assert result.startswith("ffmpeg")
     completions_mock.create.assert_called_once()
     assert completions_mock.create.call_args[1]["model"] == "gpt-3.5-turbo"
 


### PR DESCRIPTION
## Summary
- prepend `ffmpeg` in `fix_command` when the OpenAI response omits it
- check for the prefix in the existing unit test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840e628533483219d2c4a26145ef3e1